### PR TITLE
Release 1.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - All node output items now carry `pairedItem` linking back to their source input, so downstream nodes (e.g. Set/Edit Fields) can reference upstream DefensX results via `$('<node>').item` without "Paired item data is unavailable" errors. Applies to every operation — OpenAPI-driven, paginated (Usage, Users, Groups, Logs, Browser Extension Users), ID-enriched (Browser Extensions, Custom URLs), and Raw Request.
+- Simplified the pagination UI to match the n8n verification pattern used across built-in nodes: the three-field `Return All` / `Max Results` / `Page Size` layout is replaced by a `Return All` toggle plus a conditional `Limit` field (hidden when Return All is enabled). The internal page size is now chosen automatically per endpoint, so users no longer see the implementation-detail "Page Size" knob. Applies to every paginated operation — Users, Groups, Browser Extension Users, all Logs endpoints, and Usage / Usage (Current). Saved workflows continue to work: the underlying parameter key (`maxResults`) is unchanged; only the display name and visibility rules changed.
+- Hid the raw `page` and `limit` query-parameter fields on Usage → Get the current usage so they no longer duplicate the pagination UI (resolves a ROADMAP item).
 
 ## [1.0.3] - 2026-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to the n8n-nodes-defensx project will be documented in this 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [1.0.3] - 2026-04-17
 
 ### Added
 
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Improved DefensX 401/403 error handling for execution and load options, including guidance to check IP allowlist restrictions.
 - Updated GitHub Actions in release-publish workflow: `actions/checkout` v4 → v6.0.2, `actions/setup-node` v4 → v6.3.0, pinned to SHA hashes.
 - Updated .gitignore to exclude `.claude/settings.local.json`.
 - Added explicit `{ schema: 'core' }` option to YAML parsing in the OpenAPI code generator for defense-in-depth (no functional change).
@@ -24,12 +25,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - All node output items now carry `pairedItem` linking back to their source input, so downstream nodes (e.g. Set/Edit Fields) can reference upstream DefensX results via `$('<node>').item` without "Paired item data is unavailable" errors. Applies to every operation — OpenAPI-driven, paginated (Usage, Users, Groups, Logs, Browser Extension Users), ID-enriched (Browser Extensions, Custom URLs), and Raw Request.
 - Simplified the pagination UI to match the n8n verification pattern used across built-in nodes: the three-field `Return All` / `Max Results` / `Page Size` layout is replaced by a `Return All` toggle plus a conditional `Limit` field (hidden when Return All is enabled). The internal page size is now chosen automatically per endpoint, so users no longer see the implementation-detail "Page Size" knob. Applies to every paginated operation — Users, Groups, Browser Extension Users, all Logs endpoints, and Usage / Usage (Current). Saved workflows continue to work: the underlying parameter key (`maxResults`) is unchanged; only the display name and visibility rules changed.
 - Hid the raw `page` and `limit` query-parameter fields on Usage → Get the current usage so they no longer duplicate the pagination UI (resolves a ROADMAP item).
-
-## [1.0.3] - 2026-02-01
-
-### Changed
-
-- Improved DefensX 401/403 error handling for execution and load options, including guidance to check IP allowlist restrictions.
 
 ## [1.0.2] - 2025-12-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Added ROADMAP.md documenting planned node improvements.
 - Added workflow documentation for CHANGELOG.md update process.
+- Added CLAUDE.md with commands, release flow, and architecture notes for Claude Code.
 
 ### Changed
 
@@ -17,6 +18,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Updated .gitignore to exclude `.claude/settings.local.json`.
 - Added explicit `{ schema: 'core' }` option to YAML parsing in the OpenAPI code generator for defense-in-depth (no functional change).
 - Consolidated keywords in package.json.
+
+### Fixed
+
+- All node output items now carry `pairedItem` linking back to their source input, so downstream nodes (e.g. Set/Edit Fields) can reference upstream DefensX results via `$('<node>').item` without "Paired item data is unavailable" errors. Applies to every operation — OpenAPI-driven, paginated (Usage, Users, Groups, Logs, Browser Extension Users), ID-enriched (Browser Extensions, Custom URLs), and Raw Request.
 
 ## [1.0.3] - 2026-02-01
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,131 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+- `npm run build` — Regenerates OpenAPI data (`tools/generate-openapi.cjs`), compiles TypeScript from `src/` to `dist/`, and copies the `DefensX.svg` icon into `dist/nodes/DefensX/` and `dist/credentials/`. **Always run a build after changing `src/` or the OpenAPI spec** — n8n loads the package from `dist/`.
+- `npm run generate:openapi` — Regenerates `src/generated/openapi.generated.ts` from `tools/openapi/defensx-partner.yaml` without a full TypeScript compile.
+- `npm run dev` — `tsc --watch` (does not re-run `generate:openapi`; re-run that manually when the YAML spec changes).
+- `npm link` then `npm link n8n-nodes-defensx` in your n8n install to load the node locally.
+
+There is no test or lint script configured. CI (`.github/workflows/ci.yml`) only runs `npm run build` on PRs to `main`.
+
+## Release flow
+
+- Publishing is triggered by a GitHub Release (or manual `workflow_dispatch` with a tag), not by `npm publish` from a developer machine. See `.github/workflows/release-publish.yml`.
+- The workflow **verifies the git tag matches `package.json` version** and publishes via npm Trusted Publishing (OIDC, `--provenance`). Bump `package.json` before tagging, or the publish job fails.
+- `CHANGELOG.md` follows Keep a Changelog. When updating it, follow `.windsurf/workflows/update-changelog-md.md`: add to the in-progress `[Unreleased]` / current-version entry, bumping date to today if needed. Do not invent a new version header just for an intermediate change.
+
+## Architecture
+
+This is an n8n community node for the DefensX Partner API. The package ships a single programmatic node plus credential type:
+
+- `src/credentials/DefensXApi.credentials.ts` — Credential with `apiRoot` + `apiKey`. Auth is `Authorization: Bearer <apiKey>`. The credential **test request hits `/api/partner/v1/status`** and strips a trailing `/api/partner/v1` from user-entered roots so both forms work.
+- `src/nodes/DefensX/DefensX.node.ts` — The `DefensX` node class. Two execution modes (selected by the `resource` dropdown):
+  - `resource === 'raw'` → Raw Request / Custom API Query. User supplies method, endpoint under `/api/partner/v1`, query JSON, body JSON.
+  - Any other resource → Drives the OpenAPI-generated operation machinery.
+
+### OpenAPI-driven UI pipeline
+
+The node's resource/operation/parameter UI is generated from the DefensX OpenAPI spec. The pipeline is:
+
+1. **Spec** — `tools/openapi/defensx-partner.yaml` (vendored from DefensX).
+2. **Code generator** — `tools/generate-openapi.cjs` parses the YAML, resolves `$ref`s, extracts `path` + `query` parameters and JSON request bodies, derives stable IDs (either the spec's `operationId` or `METHOD_path_with_by_param`), adds date-format hints, and writes `src/generated/openapi.generated.ts` as a single exported `generatedOperations` array. **Never hand-edit `src/generated/openapi.generated.ts`** — re-run the generator.
+3. **UI builder** — `src/nodes/DefensX/openapiProperties.ts` reads `generatedOperations`, applies `src/overrides/openapiOverrides.ts` (per-operationId renames or hides), and builds n8n `INodeProperties` for the Resource dropdown, the Operation dropdown (one per resource, with `displayOptions.show.resource` gating), and every path/query/body field. Field names follow the pattern `{in}_{sanitizedOperationId}_{sanitizedParamName}` — use `getParamName(prefix, opId, name)` to look them up at runtime.
+4. **Dynamic load options** — `methods.loadOptions` on the node class exposes `getCustomerOptions`, `getBrowserExtensionOptions`, `getPolicyGroupOptions`. These call the API themselves using `helpers.httpRequestWithAuthentication` (or the legacy `requestWithAuthentication`) and depend on `getCurrentNodeParameter('operation')` plus the already-selected customer field.
+
+### Customizing an operation
+
+Prefer overrides over code changes:
+
+- Hide an endpoint from the UI → add `{ hidden: true }` to `operationOverrides` keyed by operationId.
+- Rename an operation or move it to a different resource → `operationName` / `resourceName` in the same override map.
+- Change how responses are split → the node's execute loop in `DefensX.node.ts` has per-operation branches (see the `isUsageOperation`, `isLogsOperation`, `isUsersListOperation`, `isBrowserExtensionsListOperation`, `shouldSkipPaginationParam`, `enrichResponseWithId`, `extractUsageBySubscriptions` helpers). Pagination, special response shapes, and ID-enrichment (e.g. injecting `customerId` into browser-extension items) live here rather than in the generator.
+
+### Output modes
+
+For non-raw operations the node exposes `outputMode`: `items` (one n8n item per array element; objects passed through, primitives wrapped as `{ value }`) or `raw` (full response as single item; arrays/primitives wrapped as `{ items }`). Raw Request always returns a single item.
+
+### Error handling
+
+`formatDefensXError` produces friendlier messages for 401/403 (mentioning IP allowlist as a likely cause). Use it whenever raising `NodeOperationError` from a request path.
+
+## Conventions
+
+- **TypeScript strict mode is off** (`tsconfig.json`) — the codebase uses `any` casts around n8n helper typing deliberately (`helpersAny`, `requestWithAuth`) because `httpRequestWithAuthentication` vs. legacy `requestWithAuthentication` varies across n8n versions. Keep that compatibility shim.
+- Resource label normalization (`URL` / `URLs` casing, `of` lowercase, `ID` uppercase) happens in multiple places — if you add a new label transform, update both `openapiProperties.ts` (`normalizeLabel`, `toTitleCaseWord`) and `openapiUi.ts` (`normalizeResourceName`) so the Resource dropdown and the operation UI stay consistent.
+- The Raw Request resource value is the literal string `'raw'`; operation IDs for generated operations come from the spec and must not collide with it.
+- `src/index.ts` only re-exports the credential and node classes; the `n8n` block in `package.json` is what n8n actually loads, and it points at compiled `dist/` paths.
+
+## Reference docs
+
+- DefensX Partner API: https://kb.defensx.com/docs/categories/72-Partner-API/topics/91d5908c-ee58-4e51-8397-ba6823407ff8
+- n8n node-building guide (extensive): `.windsurf/rules/n8n-nodes-building-guide.md`
+- Planned improvements: `ROADMAP.md`
+
+# Additional Behavior Guidelines
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,6 @@
 ## Usage Improvements
 
 - Usage → Get the calculated usage of customers: provide alternate plain-English date ranges in addition to datetime fields.
-- Usage → Get the current usage which is not billed yet in the current subscription term window: remove the page/limit fields that still display.
 
 ## UI Improvements
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "n8n-nodes-defensx",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "n8n-nodes-defensx",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-defensx",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "The Partner API provides access to DefensX functions for Partners and MSPs.\n\nTo use this API, you must first obtain an API key from the API Keys page in the DefensX portal.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/nodes/DefensX/DefensX.node.ts
+++ b/src/nodes/DefensX/DefensX.node.ts
@@ -457,6 +457,24 @@ interface PaginationConfig {
   supportRequestedPageAndLimit?: boolean;
 }
 
+function readPaginationParams(
+  ctx: IExecuteFunctions,
+  operationId: string,
+  itemIndex: number,
+  defaultPageSize: number,
+): { maxResults: number; pageSize: number } {
+  const returnAllParam = getParamName('pagination', operationId, 'returnAll');
+  const limitParam = getParamName('pagination', operationId, 'maxResults');
+
+  const returnAll = ctx.getNodeParameter(returnAllParam, itemIndex) as boolean;
+  const limit = returnAll
+    ? 0
+    : Math.max(0, Number(ctx.getNodeParameter(limitParam, itemIndex, defaultPageSize)) || 0);
+
+  const pageSize = limit > 0 && limit < defaultPageSize ? limit : defaultPageSize;
+  return { maxResults: limit, pageSize };
+}
+
 /**
  * Executes a paginated API request and collects all results across multiple pages.
  * This function implements a pagination strategy that automatically fetches subsequent pages
@@ -777,17 +795,9 @@ export class DefensX implements INodeType {
 
       try {
         if (isUsageOperation(operation.id)) {
-          const returnAllParam = getParamName('pagination', operation.id, 'returnAll');
-          const maxResultsParam = getParamName('pagination', operation.id, 'maxResults');
-          const pageSizeParam = getParamName('pagination', operation.id, 'pageSize');
-
-          const returnAll = this.getNodeParameter(returnAllParam, itemIndex) as boolean;
-          const maxResults = this.getNodeParameter(maxResultsParam, itemIndex) as number;
-          const configuredPageSize = this.getNodeParameter(pageSizeParam, itemIndex) as number;
+          const { maxResults, pageSize } = readPaginationParams(this, operation.id, itemIndex, 1000);
 
           const requestedPage = Number.isFinite(Number(qs.page)) && Number(qs.page) > 0 ? Number(qs.page) : 1;
-          const requestedLimit = Number.isFinite(Number(qs.limit)) && Number(qs.limit) > 0 ? Number(qs.limit) : 0;
-          const pageSize = requestedLimit || (Number.isFinite(configuredPageSize) && configuredPageSize > 0 ? configuredPageSize : 1000);
 
           const collected: unknown[] = [];
           let page = requestedPage;
@@ -808,8 +818,7 @@ export class DefensX implements INodeType {
             const usageItems = extractUsageBySubscriptions(response);
             collected.push(...usageItems);
 
-            if (maxResults && maxResults > 0 && collected.length >= maxResults) break;
-            if (!returnAll) break;
+            if (maxResults > 0 && collected.length >= maxResults) break;
 
             const currentPage = Number(responseObj?.page) || page;
             const foundTotalPages = Number(responseObj?.totalPages);
@@ -825,84 +834,60 @@ export class DefensX implements INodeType {
             page = currentPage + 1;
           }
 
-          const finalItems = maxResults && maxResults > 0 ? collected.slice(0, maxResults) : collected;
+          const finalItems = maxResults > 0 ? collected.slice(0, maxResults) : collected;
           appendResponseItems(returnItems, finalItems, outputMode, itemIndex);
         } else if (isUsersListOperation(operation.id)) {
-          const returnAllParam = getParamName('pagination', operation.id, 'returnAll');
-          const maxResultsParam = getParamName('pagination', operation.id, 'maxResults');
-          const pageSizeParam = getParamName('pagination', operation.id, 'pageSize');
-
-          const returnAll = this.getNodeParameter(returnAllParam, itemIndex) as boolean;
-          const maxResults = this.getNodeParameter(maxResultsParam, itemIndex) as number;
-          const configuredPageSize = this.getNodeParameter(pageSizeParam, itemIndex) as number;
+          const { maxResults, pageSize } = readPaginationParams(this, operation.id, itemIndex, 1000);
 
           const finalItems = await executePaginatedRequest(
             this,
             requestOptions,
             qs,
-            returnAll,
+            true,
             maxResults,
-            configuredPageSize,
+            pageSize,
             { defaultPageSize: 1000, supportRequestedPageAndLimit: true },
           );
 
           appendResponseItems(returnItems, finalItems, outputMode, itemIndex);
         } else if (isGroupsListOperation(operation.id)) {
-          const returnAllParam = getParamName('pagination', operation.id, 'returnAll');
-          const maxResultsParam = getParamName('pagination', operation.id, 'maxResults');
-          const pageSizeParam = getParamName('pagination', operation.id, 'pageSize');
-
-          const returnAll = this.getNodeParameter(returnAllParam, itemIndex) as boolean;
-          const maxResults = this.getNodeParameter(maxResultsParam, itemIndex) as number;
-          const configuredPageSize = this.getNodeParameter(pageSizeParam, itemIndex) as number;
+          const { maxResults, pageSize } = readPaginationParams(this, operation.id, itemIndex, 100);
 
           const finalItems = await executePaginatedRequest(
             this,
             requestOptions,
             qs,
-            returnAll,
+            true,
             maxResults,
-            configuredPageSize,
+            pageSize,
             { defaultPageSize: 100 },
           );
 
           appendResponseItems(returnItems, finalItems, outputMode, itemIndex);
         } else if (isLogsOperation(operation.id)) {
-          const returnAllParam = getParamName('pagination', operation.id, 'returnAll');
-          const maxResultsParam = getParamName('pagination', operation.id, 'maxResults');
-          const pageSizeParam = getParamName('pagination', operation.id, 'pageSize');
-
-          const returnAll = this.getNodeParameter(returnAllParam, itemIndex) as boolean;
-          const maxResults = this.getNodeParameter(maxResultsParam, itemIndex) as number;
-          const configuredPageSize = this.getNodeParameter(pageSizeParam, itemIndex) as number;
+          const { maxResults, pageSize } = readPaginationParams(this, operation.id, itemIndex, 100);
 
           const finalItems = await executePaginatedRequest(
             this,
             requestOptions,
             qs,
-            returnAll,
+            true,
             maxResults,
-            configuredPageSize,
+            pageSize,
             { defaultPageSize: 100 },
           );
 
           appendResponseItems(returnItems, finalItems, outputMode, itemIndex);
         } else if (isBrowserExtensionUsersOperation(operation.id)) {
-          const returnAllParam = getParamName('pagination', operation.id, 'returnAll');
-          const maxResultsParam = getParamName('pagination', operation.id, 'maxResults');
-          const pageSizeParam = getParamName('pagination', operation.id, 'pageSize');
-
-          const returnAll = this.getNodeParameter(returnAllParam, itemIndex) as boolean;
-          const maxResults = this.getNodeParameter(maxResultsParam, itemIndex) as number;
-          const configuredPageSize = this.getNodeParameter(pageSizeParam, itemIndex) as number;
+          const { maxResults, pageSize } = readPaginationParams(this, operation.id, itemIndex, 100);
 
           const finalItems = await executePaginatedRequest(
             this,
             requestOptions,
             qs,
-            returnAll,
+            true,
             maxResults,
-            configuredPageSize,
+            pageSize,
             { defaultPageSize: 100 },
           );
 

--- a/src/nodes/DefensX/DefensX.node.ts
+++ b/src/nodes/DefensX/DefensX.node.ts
@@ -78,30 +78,33 @@ function appendResponseItems(
   returnItems: INodeExecutionData[],
   response: unknown,
   outputMode: 'items' | 'raw',
+  itemIndex: number,
 ): void {
+  const pairedItem = { item: itemIndex };
+
   if (outputMode === 'items' && Array.isArray(response)) {
     for (const element of response) {
       if (typeof element === 'object' && element !== null && !Array.isArray(element)) {
-        returnItems.push({ json: element as IDataObject });
+        returnItems.push({ json: element as IDataObject, pairedItem });
         continue;
       }
 
-      returnItems.push({ json: { value: element as any } });
+      returnItems.push({ json: { value: element as any }, pairedItem });
     }
     return;
   }
 
   if (outputMode === 'raw') {
     if (typeof response === 'object' && response !== null && !Array.isArray(response)) {
-      returnItems.push({ json: response as IDataObject });
+      returnItems.push({ json: response as IDataObject, pairedItem });
       return;
     }
 
-    returnItems.push({ json: { items: response as any } });
+    returnItems.push({ json: { items: response as any }, pairedItem });
     return;
   }
 
-  returnItems.push({ json: response as any });
+  returnItems.push({ json: response as any, pairedItem });
 }
 
 /**
@@ -690,7 +693,7 @@ export class DefensX implements INodeType {
 
         try {
           const response = await requestWithDefensXAuth(this, requestOptions);
-          returnItems.push({ json: response as any });
+          returnItems.push({ json: response as any, pairedItem: { item: itemIndex } });
           continue;
         } catch (error) {
           throw new NodeOperationError(this.getNode(), formatDefensXError(error));
@@ -823,7 +826,7 @@ export class DefensX implements INodeType {
           }
 
           const finalItems = maxResults && maxResults > 0 ? collected.slice(0, maxResults) : collected;
-          appendResponseItems(returnItems, finalItems, outputMode);
+          appendResponseItems(returnItems, finalItems, outputMode, itemIndex);
         } else if (isUsersListOperation(operation.id)) {
           const returnAllParam = getParamName('pagination', operation.id, 'returnAll');
           const maxResultsParam = getParamName('pagination', operation.id, 'maxResults');
@@ -843,7 +846,7 @@ export class DefensX implements INodeType {
             { defaultPageSize: 1000, supportRequestedPageAndLimit: true },
           );
 
-          appendResponseItems(returnItems, finalItems, outputMode);
+          appendResponseItems(returnItems, finalItems, outputMode, itemIndex);
         } else if (isGroupsListOperation(operation.id)) {
           const returnAllParam = getParamName('pagination', operation.id, 'returnAll');
           const maxResultsParam = getParamName('pagination', operation.id, 'maxResults');
@@ -863,7 +866,7 @@ export class DefensX implements INodeType {
             { defaultPageSize: 100 },
           );
 
-          appendResponseItems(returnItems, finalItems, outputMode);
+          appendResponseItems(returnItems, finalItems, outputMode, itemIndex);
         } else if (isLogsOperation(operation.id)) {
           const returnAllParam = getParamName('pagination', operation.id, 'returnAll');
           const maxResultsParam = getParamName('pagination', operation.id, 'maxResults');
@@ -883,7 +886,7 @@ export class DefensX implements INodeType {
             { defaultPageSize: 100 },
           );
 
-          appendResponseItems(returnItems, finalItems, outputMode);
+          appendResponseItems(returnItems, finalItems, outputMode, itemIndex);
         } else if (isBrowserExtensionUsersOperation(operation.id)) {
           const returnAllParam = getParamName('pagination', operation.id, 'returnAll');
           const maxResultsParam = getParamName('pagination', operation.id, 'maxResults');
@@ -903,7 +906,7 @@ export class DefensX implements INodeType {
             { defaultPageSize: 100 },
           );
 
-          appendResponseItems(returnItems, finalItems, outputMode);
+          appendResponseItems(returnItems, finalItems, outputMode, itemIndex);
         } else {
           const response = await requestWithDefensXAuth(this, requestOptions);
 
@@ -914,7 +917,7 @@ export class DefensX implements INodeType {
             Array.isArray(response)
           ) {
             const enriched = enrichResponseWithId(response, 'customerId', customerIdForOutput);
-            appendResponseItems(returnItems, enriched, outputMode);
+            appendResponseItems(returnItems, enriched, outputMode, itemIndex);
             continue;
           }
 
@@ -925,9 +928,9 @@ export class DefensX implements INodeType {
             Array.isArray(response)
           ) {
             const enriched = enrichResponseWithId(response, 'customUrlGroupId', customUrlGroupIdForOutput);
-            appendResponseItems(returnItems, enriched, outputMode);
+            appendResponseItems(returnItems, enriched, outputMode, itemIndex);
           } else {
-            appendResponseItems(returnItems, response, outputMode);
+            appendResponseItems(returnItems, response, outputMode, itemIndex);
           }
         }
       } catch (error) {

--- a/src/nodes/DefensX/openapiProperties.ts
+++ b/src/nodes/DefensX/openapiProperties.ts
@@ -205,6 +205,58 @@ function getCustomerParamNameForOperation(op: GeneratedOperation): string {
   return getParamName(prefix, op.id, customerParam?.name ?? 'customerId');
 }
 
+type PaginationConfigUi = { returnAllDefault: boolean; limitDefault: number };
+
+const paginationConfigs: Record<string, PaginationConfigUi> = {
+  get_customers_by_customerid_users: { returnAllDefault: true, limitDefault: 100 },
+  get_customers_by_customerid_groups: { returnAllDefault: true, limitDefault: 100 },
+  get_customers_by_customerid_browser_extensions_by_browserextensionid_users: { returnAllDefault: true, limitDefault: 100 },
+  get_customers_by_customerid_logs_urls: { returnAllDefault: false, limitDefault: 100 },
+  get_customers_by_customerid_logs_credentials: { returnAllDefault: false, limitDefault: 100 },
+  get_customers_by_customerid_logs_file_transfers: { returnAllDefault: false, limitDefault: 100 },
+  get_customers_by_customerid_logs_consents: { returnAllDefault: false, limitDefault: 100 },
+  get_customers_by_customerid_logs_dns: { returnAllDefault: false, limitDefault: 100 },
+  get_customers_by_customerid_logs_rbi: { returnAllDefault: false, limitDefault: 100 },
+  get_usage: { returnAllDefault: true, limitDefault: 100 },
+  get_usage_current: { returnAllDefault: true, limitDefault: 100 },
+};
+
+function buildPaginationProperties(
+  operationId: string,
+  baseDisplayOptions: { show: Record<string, string[]> },
+): INodeProperties[] {
+  const cfg = paginationConfigs[operationId];
+  if (!cfg) return [];
+
+  const returnAllName = toParamName('pagination', operationId, 'returnAll');
+  const limitName = toParamName('pagination', operationId, 'maxResults');
+
+  return [
+    {
+      displayName: 'Return All',
+      name: returnAllName,
+      type: 'boolean',
+      default: cfg.returnAllDefault,
+      description: 'Whether to return all results or only up to a given limit',
+      displayOptions: baseDisplayOptions,
+    },
+    {
+      displayName: 'Limit',
+      name: limitName,
+      type: 'number',
+      typeOptions: { minValue: 1 },
+      default: cfg.limitDefault,
+      description: 'Max number of results to return',
+      displayOptions: {
+        show: {
+          ...baseDisplayOptions.show,
+          [returnAllName]: [false],
+        },
+      },
+    },
+  ];
+}
+
 export function buildOpenApiOperationProperties(): INodeProperties[] {
   const properties: INodeProperties[] = [];
 
@@ -240,7 +292,8 @@ export function buildOpenApiOperationProperties(): INodeProperties[] {
           opId === 'get_customers_by_customerid_logs_consents' ||
           opId === 'get_customers_by_customerid_logs_dns' ||
           opId === 'get_customers_by_customerid_logs_rbi' ||
-          opId === 'get_customers_by_customerid_browser_extensions_by_browserextensionid_users'
+          opId === 'get_customers_by_customerid_browser_extensions_by_browserextensionid_users' ||
+          opId === 'get_usage_current'
         ) {
           return true;
         }
@@ -309,156 +362,8 @@ export function buildOpenApiOperationProperties(): INodeProperties[] {
       });
     }
 
-    if (op.id === 'get_customers_by_customerid_users') {
-      properties.push({
-        displayName: 'Return All',
-        name: toParamName('pagination', op.id, 'returnAll'),
-        type: 'boolean',
-        default: true,
-        description: 'Whether to fetch all pages automatically.',
-        displayOptions,
-      });
-
-      properties.push({
-        displayName: 'Max Results',
-        name: toParamName('pagination', op.id, 'maxResults'),
-        type: 'number',
-        default: 0,
-        description: 'Optional maximum number of items to return (0 = no limit).',
-        displayOptions,
-      });
-
-      properties.push({
-        displayName: 'Page Size',
-        name: toParamName('pagination', op.id, 'pageSize'),
-        type: 'number',
-        default: 1000,
-        description: 'Number of records to return per page.',
-        displayOptions,
-      });
-    }
-
-    if (op.id === 'get_customers_by_customerid_groups') {
-      properties.push({
-        displayName: 'Return All',
-        name: toParamName('pagination', op.id, 'returnAll'),
-        type: 'boolean',
-        default: true,
-        description: 'Whether to fetch all pages automatically.',
-        displayOptions,
-      });
-
-      properties.push({
-        displayName: 'Max Results',
-        name: toParamName('pagination', op.id, 'maxResults'),
-        type: 'number',
-        default: 0,
-        description: 'Optional maximum number of items to return (0 = no limit).',
-        displayOptions,
-      });
-
-      properties.push({
-        displayName: 'Page Size',
-        name: toParamName('pagination', op.id, 'pageSize'),
-        type: 'number',
-        default: 100,
-        description: 'Number of records to return per page.',
-        displayOptions,
-      });
-    }
-
-    if (op.id === 'get_customers_by_customerid_browser_extensions_by_browserextensionid_users') {
-      properties.push({
-        displayName: 'Return All',
-        name: toParamName('pagination', op.id, 'returnAll'),
-        type: 'boolean',
-        default: true,
-        description: 'Whether to fetch all pages automatically.',
-        displayOptions,
-      });
-
-      properties.push({
-        displayName: 'Max Results',
-        name: toParamName('pagination', op.id, 'maxResults'),
-        type: 'number',
-        default: 0,
-        description: 'Optional maximum number of items to return (0 = no limit).',
-        displayOptions,
-      });
-
-      properties.push({
-        displayName: 'Page Size',
-        name: toParamName('pagination', op.id, 'pageSize'),
-        type: 'number',
-        default: 100,
-        description: 'Number of records to return per page.',
-        displayOptions,
-      });
-    }
-
-    if (
-      op.id === 'get_customers_by_customerid_logs_urls' ||
-      op.id === 'get_customers_by_customerid_logs_credentials' ||
-      op.id === 'get_customers_by_customerid_logs_file_transfers' ||
-      op.id === 'get_customers_by_customerid_logs_consents' ||
-      op.id === 'get_customers_by_customerid_logs_dns' ||
-      op.id === 'get_customers_by_customerid_logs_rbi'
-    ) {
-      properties.push({
-        displayName: 'Return All',
-        name: toParamName('pagination', op.id, 'returnAll'),
-        type: 'boolean',
-        default: false,
-        description: 'Whether to fetch all pages automatically.',
-        displayOptions,
-      });
-
-      properties.push({
-        displayName: 'Max Results',
-        name: toParamName('pagination', op.id, 'maxResults'),
-        type: 'number',
-        default: 0,
-        description: 'Optional maximum number of items to return (0 = no limit).',
-        displayOptions,
-      });
-
-      properties.push({
-        displayName: 'Page Size',
-        name: toParamName('pagination', op.id, 'pageSize'),
-        type: 'number',
-        default: 100,
-        description: 'Number of records to return per page.',
-        displayOptions,
-      });
-    }
-
-    if (op.id === 'get_usage' || op.id === 'get_usage_current') {
-      properties.push({
-        displayName: 'Return All',
-        name: toParamName('pagination', op.id, 'returnAll'),
-        type: 'boolean',
-        default: true,
-        description: 'Whether to fetch all pages automatically.',
-        displayOptions,
-      });
-
-      properties.push({
-        displayName: 'Max Results',
-        name: toParamName('pagination', op.id, 'maxResults'),
-        type: 'number',
-        default: 0,
-        description: 'Optional maximum number of items to return (0 = no limit).',
-        displayOptions,
-      });
-
-      properties.push({
-        displayName: 'Page Size',
-        name: toParamName('pagination', op.id, 'pageSize'),
-        type: 'number',
-        default: 1000,
-        description: 'Number of records to return per page.',
-        displayOptions,
-      });
+    for (const p of buildPaginationProperties(op.id, displayOptions)) {
+      properties.push(p);
     }
 
     if (op.requestBody) {


### PR DESCRIPTION
## Summary
- Fix `pairedItem` linking on every operation so downstream nodes (Set/Edit Fields, etc.) can reference DefensX results via `$('<node>').item` without "Paired item data is unavailable" errors.
- Simplify pagination UI to the standard n8n `Return All` + conditional `Limit` pattern; internal page size is now chosen automatically per endpoint. Applies to Users, Groups, Browser Extension Users, all Logs endpoints, and Usage / Usage (Current).
- Hide raw `page` / `limit` query-parameter fields on Usage → Get the current usage so they no longer duplicate the pagination UI (resolves a ROADMAP item).
- Add CLAUDE.md with commands, release flow, and architecture notes.
- Include previously-unreleased 1.0.3 work: improved 401/403 error handling with IP allowlist guidance.

## Test plan
- [ ] CI build passes (`npm run build`).
- [ ] Install the built `dist/` in a self-hosted n8n and verify `$('<DefensX node>').item` resolves in a downstream Set node for at least one paginated operation (e.g. Browser Extensions → users) and one non-paginated operation.
- [ ] Confirm pagination UI shows only `Return All` + conditional `Limit` (no `Max Results` or `Page Size`).
- [ ] Confirm Usage (Current) no longer shows raw `page` / `limit` query fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)