### PR TITLE
Release 1.0.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node
         uses: actions/setup-node@v4

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -35,7 +35,7 @@ jobs:
           echo "Using tag: $(cat $GITHUB_OUTPUT | sed -n 's/^release_tag=//p')"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ steps.vars.outputs.release_tag }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to the n8n-nodes-defensx project will be documented in this 
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+
+- Pinned `actions/checkout` to v6.0.2 by SHA in both CI and release-publish workflows (previously `@v4`), addressing the Node.js 20 deprecation warning emitted by GitHub Actions and matching the SHA-pinning style already used for `actions/setup-node`.
+
 ## [1.0.3] - 2026-04-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [1.0.4] - 2026-04-30
+
+### Fixed
+
+- Fixed "Could not get parameter `query_get_usage_current_page`" error when running Usage → Get the current usage. The runtime parameter loop now skips the hidden `page` and `limit` query fields for `get_usage_current`, matching the UI hide added in 1.0.3.
+
 ### Changed
 
 - Pinned `actions/checkout` to v6.0.2 by SHA in both CI and release-publish workflows (previously `@v4`), addressing the Node.js 20 deprecation warning emitted by GitHub Actions and matching the SHA-pinning style already used for `actions/setup-node`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "n8n-nodes-defensx",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "The Partner API provides access to DefensX functions for Partners and MSPs.\n\nTo use this API, you must first obtain an API key from the API Keys page in the DefensX portal.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/nodes/DefensX/DefensX.node.ts
+++ b/src/nodes/DefensX/DefensX.node.ts
@@ -346,7 +346,8 @@ function shouldSkipPaginationParam(operationId: string, paramIn: string, paramNa
     isUsersListOperation(operationId) ||
     isGroupsListOperation(operationId) ||
     isLogsOperation(operationId) ||
-    isBrowserExtensionUsersOperation(operationId)
+    isBrowserExtensionUsersOperation(operationId) ||
+    operationId === 'get_usage_current'
   );
 }
 


### PR DESCRIPTION
## Summary

- Fix "Could not get parameter \`query_get_usage_current_page\`" error when running Usage → Get the current usage. After 1.0.3 hid the raw `page`/`limit` UI fields for `get_usage_current`, the runtime parameter loop still tried to read them — now it skips them too.
- Bump version to 1.0.4 and update CHANGELOG.

## Test plan

- [ ] In n8n, run Usage → Get the current usage and confirm it returns data without a parameter error.
- [ ] Confirm other paginated operations (Users, Groups, Logs, Browser Extension Users, Usage) still paginate correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)