### PR TITLE
Fix: preserve JSON array request bodies (custom URL create sends {})

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed array-type request bodies being dropped. `parseJsonParameter` returned `{}` for any parsed JSON array, so operations whose body schema is an array — e.g. **Create one or more custom urls in specific custom url group** (`POST /customers/{customerId}/custom_url_groups/{customUrlGroupId}/custom_urls`) — always sent `{}` and the API rejected the request. Arrays now pass through; affects both generated operations and the Raw Request path.
+
 ## [1.0.4] - 2026-04-30
 
 ### Fixed

--- a/src/nodes/DefensX/DefensX.node.ts
+++ b/src/nodes/DefensX/DefensX.node.ts
@@ -28,15 +28,15 @@ function parseJsonParameter(
   ctx: IExecuteFunctions,
   value: NodeParameterValue,
   errorPrefix: string,
-): Record<string, unknown> {
+): Record<string, unknown> | unknown[] {
   if (value === null || value === undefined) return {};
-  if (typeof value === 'object') return value as Record<string, unknown>;
+  if (typeof value === 'object') return value as Record<string, unknown> | unknown[];
   if (typeof value === 'string') {
     if (!value.trim()) return {};
     try {
       const parsed = JSON.parse(value);
-      if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
-        return parsed as Record<string, unknown>;
+      if (typeof parsed === 'object' && parsed !== null) {
+        return parsed as Record<string, unknown> | unknown[];
       }
       return {};
     } catch (error) {
@@ -762,7 +762,7 @@ export class DefensX implements INodeType {
 
       const url = buildRequestUrl(apiRoot, resolvedPath);
 
-      let requestBody: Record<string, unknown> | undefined;
+      let requestBody: Record<string, unknown> | unknown[] | undefined;
       if (operation.requestBody) {
         const jsonOverrideName = getParamName('bodyJson', operation.id, 'json');
         const overrideValue = this.getNodeParameter(jsonOverrideName, itemIndex) as NodeParameterValue;


### PR DESCRIPTION
### Problem

Operations whose request body schema is `type: array` — e.g. **Create one or more custom urls in specific custom url group** (`POST /customers/{customerId}/custom_url_groups/{customUrlGroupId}/custom_urls`) — always send `{}`, so the API rejects them with *"request is invalid."*

`parseJsonParameter` parses the JSON, then:

```js
if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
  return parsed;
}
return {};
```

The `!Array.isArray(parsed)` guard sends every array to the `return {}` fallback. Affects both generated operations and the Raw Request path.

**Repro:** set the body to `["example.com"]` on the custom-URL create op → API error; the node actually transmits `{}`.

### Fix

Drop the `!Array.isArray` guard so arrays pass through; widen the `parseJsonParameter` return type and `requestBody` to `Record<string, unknown> | unknown[]`. One-line behavior change, `tsc --noEmit` clean. CHANGELOG `[Unreleased]` updated.